### PR TITLE
fix list method for cluster and app

### DIFF
--- a/pkg/datastore/mongodb/mongodb.go
+++ b/pkg/datastore/mongodb/mongodb.go
@@ -59,7 +59,7 @@ func (m *mongodb) Put(ctx context.Context, kind, name string, entity interface{}
 func (m *mongodb) Find(ctx context.Context, kind string) (datastore.Iterator, error) {
 	collection := m.client.Database(m.database).Collection(kind)
 	// bson.D{{}} specifies 'all documents'
-	filter := bson.D{{}}
+	filter := bson.D{}
 	cur, err := collection.Find(ctx, filter)
 	if err != nil {
 		return nil, err

--- a/pkg/rest/rest_server.go
+++ b/pkg/rest/rest_server.go
@@ -79,7 +79,8 @@ func (s *restServer) registerServices() {
 
 	clusterStore := storeadapter.NewClusterStore(s.ds)
 	clusterService := services.NewClusterService(clusterStore)
-	s.server.GET("/api/clusters", clusterService.GetClusters)
+	s.server.GET("/api/cluster", clusterService.GetCluster)
+	s.server.GET("/api/clusters", clusterService.ListClusters)
 	s.server.GET("/api/clusternames", clusterService.GetClusterNames)
 	s.server.POST("/api/clusters", clusterService.AddCluster)
 	s.server.PUT("/api/clusters", clusterService.UpdateCluster)

--- a/pkg/rest/services/cluster.go
+++ b/pkg/rest/services/cluster.go
@@ -35,12 +35,21 @@ func (s *ClusterService) GetClusterNames(c echo.Context) error {
 	return c.JSON(http.StatusOK, apis.ClustersMeta{Clusters: names})
 }
 
-func (s *ClusterService) GetClusters(c echo.Context) error {
+func (s *ClusterService) ListClusters(c echo.Context) error {
 	clusters, err := s.store.ListClusters()
 	if err != nil {
 		return err
 	}
 	return c.JSON(http.StatusOK, model.ClusterListResponse{Clusters: clusters})
+}
+
+func (s *ClusterService) GetCluster(c echo.Context) error {
+	clusterName := c.QueryParam("clusterName")
+	cluster, err := s.store.GetCluster(clusterName)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, model.ClusterResponse{Cluster: cluster})
 }
 
 func (s *ClusterService) AddCluster(c echo.Context) error {


### PR DESCRIPTION
1. Previous list request  for list cluster and application  get empty response.
Because the iter get from "iter, err := c.ds.Find(ctx, clusterKind)"  in clusterstore.go do not have iter.next()

We fix the Find method.
The web before fix list method:
![image](https://user-images.githubusercontent.com/35907099/120602538-b31e5e00-c47d-11eb-878b-17db39be4a84.png)
After fix:
![image](https://user-images.githubusercontent.com/35907099/120602837-fbd61700-c47d-11eb-9d6a-a0b92b560967.png)
![image](https://user-images.githubusercontent.com/35907099/120602989-1d370300-c47e-11eb-939c-b5df6982303c.png)
2. Also add  GetCluster from clusterName and  use existing clusterResponse struct for return.
3. Find a wrong request  may in application/index.tsx
The url lack "/api/clusterName/"
![image](https://user-images.githubusercontent.com/35907099/120603529-b9610a00-c47e-11eb-9e16-e627766d0ece.png)




 
